### PR TITLE
Improve download script and idempotent install

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,16 @@
 
 This repository contains simple scripts for installing Ruby 2.7 from a Snap package and configuring the environment to use it.
 
-- **snap_download.sh** – Downloads a package from the Snap repository.
-- **install_ruby.sh** – Installs Ruby 2.7 using a downloaded Snap package.
+- **snap_download.sh** – Downloads a package from the Snap repository. The
+  destination filename can be specified as an optional argument.
+- **install_ruby.sh** – Installs Ruby 2.7 using a downloaded Snap package and
+  skips steps when files already exist.
 - **env.sh** – Sets environment variables for running Ruby 2.7.
 
 ## Usage
 
-1. Run `install_ruby.sh` as root to download and extract the Ruby 2.7 Snap package.
+1. Run `install_ruby.sh` as root to download and extract the Ruby 2.7 Snap package. If the
+   `ruby27.snap` file or extracted directory already exist, those steps are skipped.
 2. Source `env.sh` to update the environment variables for your shell.
 
 These scripts are experimental and assume a Linux environment with Snap and `squashfs-tools` available.

--- a/install_ruby.sh
+++ b/install_ruby.sh
@@ -1,10 +1,20 @@
 #!/bin/sh
 
-apt install squashfs-tools
+set -euo pipefail
 
-./download-snap.sh ruby 2.7/stable
+apt-get update
+apt-get install -y squashfs-tools
 
-unsquashfs ruby_308.snap.snap -d /opt/ruby27-snap
+SNAP_FILE="ruby27.snap"
+SNAP_DIR="/opt/ruby27-snap"
+
+if [ ! -f "$SNAP_FILE" ]; then
+  ./snap_download.sh ruby 2.7/stable "$(dpkg --print-architecture)" "$SNAP_FILE"
+fi
+
+if [ ! -d "$SNAP_DIR" ]; then
+  unsquashfs "$SNAP_FILE" -d "$SNAP_DIR"
+fi
 
 mkdir -p /snap/core20/current/lib64
-ln -s /lib64/ld-linux-x86-64.so.2 /snap/core20/current/lib64/ld-linux-x86-64.so.2
+ln -sf /lib64/ld-linux-x86-64.so.2 /snap/core20/current/lib64/ld-linux-x86-64.so.2

--- a/snap_download.sh
+++ b/snap_download.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
-# download-snap.sh  <snap名>  <トラック/リスク>  [arch]
-# 例: ./download-snap.sh ruby 2.7/stable amd64
+# download-snap.sh  <snap名>  <トラック/リスク>  [arch] [保存ファイル名]
+# 例: ./download-snap.sh ruby 2.7/stable amd64 ruby27.snap
 
 set -euo pipefail
 
 SNAP_NAME=${1:? "snap 名を指定してください"}
 CHANNEL=${2:-stable}          # 例: "2.7/stable" や "beta"
 ARCH=${3:-$(dpkg --print-architecture)}  # 省略時はホストの arch
+OUTPUT_FILE=${4:-}
 SERIES=16                     # 現行デバイス・シリーズは 16 で固定
 
 # --- 1) メタデータ取得 -------------------------------------------------------
@@ -23,7 +24,11 @@ REVISION=$(echo "${ENTRY}"   | jq -r '.revision')
 DOWNLOAD_URL=$(echo "${ENTRY}" | jq -r '.download.url')
 SNAP_ID=$(echo "${INFO_JSON}" | jq -r '.snap_id')
 
-F_SNAP="${SNAP_NAME}_${REVISION}_${ARCH}.snap"
+if [ -n "${OUTPUT_FILE}" ]; then
+  F_SNAP="${OUTPUT_FILE}"
+else
+  F_SNAP="${SNAP_NAME}_${REVISION}_${ARCH}.snap"
+fi
 F_ASSERT="${SNAP_NAME}_${REVISION}.assert"
 
 echo "▼ download .snap (${F_SNAP})"


### PR DESCRIPTION
## Summary
- allow specifying output filename in `snap_download.sh`
- make `install_ruby.sh` skip downloading/extracting when already done
- update README with new behaviour

## Testing
- `bash -n snap_download.sh install_ruby.sh env.sh`

------
https://chatgpt.com/codex/tasks/task_e_6889b5a6bc60832bae277e76dea66fdf