### PR TITLE
Update install script to check installed packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,17 @@ This repository contains simple scripts for installing Ruby 2.7 from a Snap pack
 
 - **snap_download.sh** – Downloads a package from the Snap repository. The
   destination filename can be specified as an optional argument.
-- **install_ruby.sh** – Installs Ruby 2.7 using a downloaded Snap package and
-  skips steps when files already exist.
+- **install_ruby.sh** – Installs Ruby 2.7 using a downloaded Snap package,
+  skipping steps when files already exist and only running `apt` commands when
+  required packages are missing.
 - **env.sh** – Sets environment variables for running Ruby 2.7.
 
 ## Usage
 
 1. Run `install_ruby.sh` as root to download and extract the Ruby 2.7 Snap package. If the
    `ruby27.snap` file or extracted directory already exist, those steps are skipped.
+   Required packages are installed only when missing, so `apt-get update` and
+   `apt-get install` are skipped if everything is already present.
 2. Source `env.sh` to update the environment variables for your shell.
 
 These scripts are experimental and assume a Linux environment with Snap and `squashfs-tools` available.

--- a/install_ruby.sh
+++ b/install_ruby.sh
@@ -2,8 +2,19 @@
 
 set -euo pipefail
 
-apt-get update
-apt-get install -y squashfs-tools curl jq
+# Skip apt operations when all required packages are installed
+PACKAGES=(squashfs-tools curl jq)
+MISSING=()
+for pkg in "${PACKAGES[@]}"; do
+  if ! dpkg -s "$pkg" >/dev/null 2>&1; then
+    MISSING+=("$pkg")
+  fi
+done
+
+if [ ${#MISSING[@]} -gt 0 ]; then
+  apt-get update
+  apt-get install -y "${MISSING[@]}"
+fi
 
 SNAP_FILE="ruby27.snap"
 SNAP_DIR="/opt/ruby27"


### PR DESCRIPTION
## Summary
- avoid running `apt-get update` and `apt-get install` when packages are already installed
- document the new behaviour in README

## Testing
- `bash -n install_ruby.sh`

------
https://chatgpt.com/codex/tasks/task_e_6889b9442400832bb2ff036476493422