### PR TITLE
Update snap download script to accept output directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@
 This repository contains simple scripts for installing Ruby 2.7 from a Snap package and configuring the environment to use it.
 
 - **snap_download.sh** – Downloads a package from the Snap repository. The
-  destination filename can be specified as an optional argument.
+  destination directory for the `.snap` and `.assert` files can be specified as
+  an optional argument; the directory is created if it does not exist.
 - **install_ruby.sh** – Installs Ruby 2.7 using a downloaded Snap package,
-  skipping steps when files already exist and only running `apt` commands when
-  required packages are missing.
+  skipping extraction when the destination directory already exists and only
+  running `apt` commands when required packages are missing.
 - **activate.sh** – Sets environment variables for running Ruby 2.7 and saves
   the previous values so they can be restored with `deactivate.sh`.
 - **deactivate.sh** – Restores the environment to its previous state.
@@ -14,7 +15,7 @@ This repository contains simple scripts for installing Ruby 2.7 from a Snap pack
 ## Usage
 
 1. Run `install_ruby.sh` as root to download and extract the Ruby 2.7 Snap package. If the
-   `ruby27.snap` file or extracted directory already exist, those steps are skipped.
+   extraction directory already exists, that step is skipped.
    Required packages are installed only when missing, so `apt-get update` and
    `apt-get install` are skipped if everything is already present.
 2. Source `activate.sh` to update the environment variables for your shell.

--- a/install_ruby.sh
+++ b/install_ruby.sh
@@ -17,12 +17,11 @@ if [ ${#MISSING[@]} -gt 0 ]; then
   apt-get install -y "${MISSING[@]}"
 fi
 
-SNAP_FILE="ruby27.snap"
+DOWNLOAD_DIR="."
 SNAP_DIR="/opt/ruby27"
 
-if [ ! -f "$SNAP_FILE" ]; then
-  ./snap_download.sh ruby 2.7/stable "$(dpkg --print-architecture)" "$SNAP_FILE"
-fi
+INFO=$(./snap_download.sh ruby 2.7/stable "$(dpkg --print-architecture)" "$DOWNLOAD_DIR")
+SNAP_FILE=$(echo "$INFO" | grep '^SNAP=' | cut -d= -f2)
 
 if [ ! -d "$SNAP_DIR" ]; then
   unsquashfs -d "$SNAP_DIR" "$SNAP_FILE"

--- a/snap_download.sh
+++ b/snap_download.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
-# download-snap.sh  <snap名>  <トラック/リスク>  [arch] [保存ファイル名]
-# 例: ./download-snap.sh ruby 2.7/stable amd64 ruby27.snap
+# download-snap.sh  <snap名>  <トラック/リスク>  [arch] [保存フォルダ]
+# 例: ./download-snap.sh ruby 2.7/stable amd64 downloads
 
 set -euo pipefail
 
 SNAP_NAME=${1:? "snap 名を指定してください"}
 CHANNEL=${2:-stable}          # 例: "2.7/stable" や "beta"
 ARCH=${3:-$(dpkg --print-architecture)}  # 省略時はホストの arch
-OUTPUT_FILE=${4:-}
+OUTPUT_DIR=${4:-.}
 SERIES=16                     # 現行デバイス・シリーズは 16 で固定
 
 # --- 1) メタデータ取得 -------------------------------------------------------
@@ -24,22 +24,22 @@ REVISION=$(echo "${ENTRY}"   | jq -r '.revision')
 DOWNLOAD_URL=$(echo "${ENTRY}" | jq -r '.download.url')
 SNAP_ID=$(echo "${INFO_JSON}" | jq -r '.snap_id')
 
-if [ -n "${OUTPUT_FILE}" ]; then
-  F_SNAP="${OUTPUT_FILE}"
-else
-  F_SNAP="${SNAP_NAME}_${REVISION}_${ARCH}.snap"
-fi
+mkdir -p "${OUTPUT_DIR}"
+
+F_SNAP="${SNAP_NAME}_${REVISION}_${ARCH}.snap"
 F_ASSERT="${SNAP_NAME}_${REVISION}.assert"
+SNAP_PATH="${OUTPUT_DIR%/}/${F_SNAP}"
+ASSERT_PATH="${OUTPUT_DIR%/}/${F_ASSERT}"
 
-echo "▼ download .snap (${F_SNAP})"
-curl -L -C - -o "${F_SNAP}"  "${DOWNLOAD_URL}"
+echo "▼ download .snap (${SNAP_PATH})"
+curl -L -C - -o "${SNAP_PATH}"  "${DOWNLOAD_URL}"
 
-echo "▼ download .assert (${F_ASSERT})"
-curl -sSL -o "${F_ASSERT}" \
+echo "▼ download .assert (${ASSERT_PATH})"
+curl -sSL -o "${ASSERT_PATH}" \
   "https://api.snapcraft.io/api/v1/snaps/assertions/snap-revision/${SNAP_ID}_${REVISION}.assert"
 
 cat <<EOF
 completed
-SNAP=${F_SNAP}
-ASSERT=${F_ASSERT}
+SNAP=${SNAP_PATH}
+ASSERT=${ASSERT_PATH}
 EOF


### PR DESCRIPTION
## Summary
- update `snap_download.sh` to take an optional destination directory
- adjust `install_ruby.sh` to parse the downloaded file name
- document new behaviour in `README`

## Testing
- `shellcheck install_ruby.sh snap_download.sh activate.sh deactivate.sh`
- `bash snap_download.sh ruby 2.7/stable amd64 tmp_output_dir | head`

------
https://chatgpt.com/codex/tasks/task_e_6889e3fe3e84832b9fbc4e817e5b7dcb