### PR TITLE
Add generic snap installation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@ This repository contains simple scripts for installing Ruby 2.7 from a Snap pack
 - **snap_download.sh** – Downloads a package from the Snap repository. The
   destination directory for the `.snap` and `.assert` files can be specified as
   an optional argument; the directory is created if it does not exist.
+- **install_snap.sh** – Extracts a previously downloaded `.snap` into
+  `/snap/<name>/<revision>/`. This works for any snap package when given the
+  package name and download folder.
 - **install_ruby.sh** – Installs Ruby 2.7 using a downloaded Snap package,
   skipping extraction when the destination directory already exists and only
   running `apt` commands when required packages are missing.
@@ -21,6 +24,8 @@ This repository contains simple scripts for installing Ruby 2.7 from a Snap pack
 2. Source `activate.sh` to update the environment variables for your shell.
    When you are done using this Ruby environment, source `deactivate.sh` to
    restore your previous settings.
+3. Use `install_snap.sh <name> <dir>` to extract a previously downloaded snap
+   into `/snap/<name>/<revision>/`. The snap must already exist in `<dir>`.
 
 These scripts are experimental and assume a Linux environment with Snap and `squashfs-tools` available.
 

--- a/install_snap.sh
+++ b/install_snap.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Install a snap package from a pre-downloaded .snap file
+# Usage: ./install_snap.sh <snap-name> <download-dir> [target-dir]
+# - <snap-name>:    Name of the snap (e.g. ruby)
+# - <download-dir>: Directory containing the downloaded .snap file
+# - [target-dir]:   Parent directory for extraction (default /snap)
+
+set -euo pipefail
+
+SNAP_NAME=${1:?"Snap name required"}
+DOWNLOAD_DIR=${2:?"Path to downloaded snaps required"}
+TARGET_PARENT=${3:-/snap}
+
+# Locate the snap file
+SNAP_FILE=$(find "$DOWNLOAD_DIR" -maxdepth 1 -name "${SNAP_NAME}_*.snap" | head -n 1 || true)
+if [ -z "$SNAP_FILE" ]; then
+  echo "Snap file for $SNAP_NAME not found in $DOWNLOAD_DIR" >&2
+  exit 1
+fi
+
+REVISION=$(basename "$SNAP_FILE" | awk -F_ '{print $2}')
+TARGET_DIR="$TARGET_PARENT/$SNAP_NAME/$REVISION"
+
+if [ ! -d "$TARGET_DIR" ]; then
+  mkdir -p "$TARGET_DIR"
+  unsquashfs -d "$TARGET_DIR" "$SNAP_FILE"
+fi
+
+cat <<EOF2
+completed
+SNAP_FILE=$SNAP_FILE
+TARGET_DIR=$TARGET_DIR
+EOF2


### PR DESCRIPTION
## Summary
- add `install_snap.sh` for extracting downloaded snap packages
- document new script and usage in README

## Testing
- `shellcheck install_ruby.sh`
- `shellcheck snap_download.sh`
- `shellcheck install_snap.sh`

------
https://chatgpt.com/codex/tasks/task_e_6889ea638c94832ba1fe53958ee8701a