### PR TITLE
Add script to unpack snap via assert file

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ This repository contains simple scripts for installing Ruby 2.7 from a Snap pack
 - **install_snap.sh** – Extracts a previously downloaded `.snap` into
   `/snap/<name>/<revision>/`. This works for any snap package when given the
   package name and download folder.
+- **install_assert.sh** – Uses a downloaded `.assert` file to determine the
+  package name and revision, then extracts the matching `.snap` into
+  `/snap/<name>/<revision>/`.
 - **install_ruby.sh** – Installs Ruby 2.7 using a downloaded Snap package,
   skipping extraction when the destination directory already exists and only
   running `apt` commands when required packages are missing.
@@ -26,6 +29,9 @@ This repository contains simple scripts for installing Ruby 2.7 from a Snap pack
    restore your previous settings.
 3. Use `install_snap.sh <name> <dir>` to extract a previously downloaded snap
    into `/snap/<name>/<revision>/`. The snap must already exist in `<dir>`.
+4. Use `install_assert.sh <file>` to extract the package specified by a
+   downloaded `.assert` file. The corresponding `.snap` must be in the same
+   directory unless a different download folder is given.
 
 These scripts are experimental and assume a Linux environment with Snap and `squashfs-tools` available.
 

--- a/install_assert.sh
+++ b/install_assert.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# Install a snap package using a downloaded .assert file to determine the name and revision
+# Usage: ./install_assert.sh <assert-file> [download-dir] [target-dir]
+# - <assert-file>: Path to the .assert file
+# - [download-dir]: Directory containing the corresponding .snap (default dirname of assert)
+# - [target-dir]:   Parent directory for extraction (default /snap)
+
+set -euo pipefail
+
+ASSERT_FILE=${1:?"Path to .assert file required"}
+DOWNLOAD_DIR=${2:-$(dirname "$ASSERT_FILE")}
+TARGET_PARENT=${3:-/snap}
+
+SNAP_NAME=$(awk -F': ' '/^snap-name:/ {print $2; exit}' "$ASSERT_FILE")
+REVISION=$(awk -F': ' '/^snap-revision:/ {print $2; exit}' "$ASSERT_FILE")
+
+if [[ -z "$SNAP_NAME" || -z "$REVISION" ]]; then
+  echo "Failed to parse snap-name or snap-revision from $ASSERT_FILE" >&2
+  exit 1
+fi
+
+SNAP_FILE=$(find "$DOWNLOAD_DIR" -maxdepth 1 -name "${SNAP_NAME}_${REVISION}_*.snap" | head -n 1 || true)
+if [ -z "$SNAP_FILE" ]; then
+  echo "Snap file for $SNAP_NAME revision $REVISION not found in $DOWNLOAD_DIR" >&2
+  exit 1
+fi
+
+TARGET_DIR="$TARGET_PARENT/$SNAP_NAME/$REVISION"
+
+if [ ! -d "$TARGET_DIR" ]; then
+  mkdir -p "$TARGET_DIR"
+  unsquashfs -d "$TARGET_DIR" "$SNAP_FILE"
+fi
+
+cat <<EOF2
+completed
+SNAP_FILE=$SNAP_FILE
+TARGET_DIR=$TARGET_DIR
+EOF2
+


### PR DESCRIPTION
## Summary
- enable installing a snap using its `.assert` file
- document new `install_assert.sh` script

## Testing
- `bash -n install_assert.sh`
- `bash -n install_snap.sh`
- `bash -n snap_download.sh`
- `bash -n install_ruby.sh`


------
https://chatgpt.com/codex/tasks/task_e_6889eef1668c832bb5c685c3a03c43a3