### PR TITLE
Update installer to use install_assert

### DIFF
--- a/activate.sh
+++ b/activate.sh
@@ -1,5 +1,5 @@
 # Environment activation for Ruby 2.7 installed from the Snap package
-SNAP=/opt/ruby27
+SNAP=/snap/ruby/current
 
 # Save current values to allow restoring them later
 [ -z "${RUBY27_OLD_PATH+x}" ] && RUBY27_OLD_PATH="${PATH:-}"

--- a/install_ruby.sh
+++ b/install_ruby.sh
@@ -18,14 +18,20 @@ if [ ${#MISSING[@]} -gt 0 ]; then
 fi
 
 DOWNLOAD_DIR="."
-SNAP_DIR="/opt/ruby27"
+ARCH="$(dpkg --print-architecture)"
 
-INFO=$(./snap_download.sh ruby 2.7/stable "$(dpkg --print-architecture)" "$DOWNLOAD_DIR")
-SNAP_FILE=$(echo "$INFO" | grep '^SNAP=' | cut -d= -f2)
-
-if [ ! -d "$SNAP_DIR" ]; then
-  unsquashfs -d "$SNAP_DIR" "$SNAP_FILE"
-fi
-
+# Install core20 using install_assert.sh
+CORE_INFO=$(./snap_download.sh core20 stable "$ARCH" "$DOWNLOAD_DIR")
+CORE_ASSERT=$(echo "$CORE_INFO" | grep '^ASSERT=' | cut -d= -f2)
+CORE_RESULT=$(./install_assert.sh "$CORE_ASSERT" "$DOWNLOAD_DIR" /snap)
+CORE_TARGET=$(echo "$CORE_RESULT" | grep '^TARGET_DIR=' | cut -d= -f2)
+ln -sfn "$CORE_TARGET" /snap/core20/current
 mkdir -p /snap/core20/current/lib64
 ln -sf /lib64/ld-linux-x86-64.so.2 /snap/core20/current/lib64/ld-linux-x86-64.so.2
+
+# Install Ruby 2.7 using install_assert.sh
+RUBY_INFO=$(./snap_download.sh ruby 2.7/stable "$ARCH" "$DOWNLOAD_DIR")
+RUBY_ASSERT=$(echo "$RUBY_INFO" | grep '^ASSERT=' | cut -d= -f2)
+RUBY_RESULT=$(./install_assert.sh "$RUBY_ASSERT" "$DOWNLOAD_DIR" /snap)
+RUBY_TARGET=$(echo "$RUBY_RESULT" | grep '^TARGET_DIR=' | cut -d= -f2)
+ln -sfn "$RUBY_TARGET" /snap/ruby/current


### PR DESCRIPTION
## Summary
- use `install_assert.sh` from `install_ruby.sh` to unpack ruby and core20
- update installation paths to `/snap/ruby/current`
- adjust `activate.sh` accordingly

## Testing
- `bash -n install_ruby.sh`
- `bash -n activate.sh`


------
https://chatgpt.com/codex/tasks/task_e_6889f171f5c8832b98704a69048d6e94