### PR TITLE
Rename scripts and update installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,9 @@ This repository contains simple scripts for installing Ruby 2.7 from a Snap pack
 - **snap_download.sh** – Downloads a package from the Snap repository. The
   destination directory for the `.snap` and `.assert` files can be specified as
   an optional argument; the directory is created if it does not exist.
-- **install_snap.sh** – Extracts a previously downloaded `.snap` into
-  `/snap/<name>/<revision>/`. This works for any snap package when given the
-  package name and download folder.
-- **install_assert.sh** – Uses a downloaded `.assert` file to determine the
-  package name and revision, then extracts the matching `.snap` into
-  `/snap/<name>/<revision>/`.
-- **install_ruby.sh** – Installs Ruby 2.7 using a downloaded Snap package,
+- **snap_install.sh** – Installs a Snap package using downloaded `.assert` and
+  `.snap` files, extracting to `/snap/<name>/<revision>/`.
+- **setup.sh** – Installs Ruby 2.7 using a downloaded Snap package,
   skipping extraction when the destination directory already exists and only
   running `apt` commands when required packages are missing.
 - **activate.sh** – Sets environment variables for running Ruby 2.7 and saves
@@ -20,18 +16,15 @@ This repository contains simple scripts for installing Ruby 2.7 from a Snap pack
 
 ## Usage
 
-1. Run `install_ruby.sh` as root to download and extract the Ruby 2.7 Snap package. If the
+1. Run `setup.sh` as root to download and extract the Ruby 2.7 Snap package. If the
    extraction directory already exists, that step is skipped.
    Required packages are installed only when missing, so `apt-get update` and
    `apt-get install` are skipped if everything is already present.
 2. Source `activate.sh` to update the environment variables for your shell.
    When you are done using this Ruby environment, source `deactivate.sh` to
    restore your previous settings.
-3. Use `install_snap.sh <name> <dir>` to extract a previously downloaded snap
-   into `/snap/<name>/<revision>/`. The snap must already exist in `<dir>`.
-4. Use `install_assert.sh <file>` to extract the package specified by a
-   downloaded `.assert` file. The corresponding `.snap` must be in the same
-   directory unless a different download folder is given.
+3. Use `snap_install.sh <assert> <snap>` to extract a previously downloaded
+   package into `/snap/<name>/<revision>/`.
 
 These scripts are experimental and assume a Linux environment with Snap and `squashfs-tools` available.
 
@@ -40,7 +33,7 @@ These scripts are experimental and assume a Linux environment with Snap and `squ
 ```bash
 mise settings add idiomatic_version_file_enable_tools "[]"
 git clone https://github.com/naoto-aoki-fy/ruby27_snap.git ruby27_snap
-./ruby27_snap/install_ruby.sh
+./ruby27_snap/setup.sh
 
 echo >> "$HOME/.bashrc"
 echo source "$PWD"/ruby27_snap/activate.sh >> "$HOME/.bashrc"

--- a/setup.sh
+++ b/setup.sh
@@ -20,16 +20,18 @@ fi
 DOWNLOAD_DIR="."
 ARCH="$(dpkg --print-architecture)"
 
-# Install core20 using install_assert.sh
+# Install core20 using snap_install.sh
 CORE_INFO=$(./snap_download.sh core20 stable "$ARCH" "$DOWNLOAD_DIR")
 CORE_ASSERT=$(echo "$CORE_INFO" | grep '^ASSERT=' | cut -d= -f2)
-CORE_RESULT=$(./install_assert.sh "$CORE_ASSERT" "$DOWNLOAD_DIR" /snap)
+CORE_SNAP=$(echo "$CORE_INFO" | grep '^SNAP=' | cut -d= -f2)
+CORE_RESULT=$(./snap_install.sh "$CORE_ASSERT" "$CORE_SNAP" /snap)
 CORE_TARGET=$(echo "$CORE_RESULT" | grep '^TARGET_DIR=' | cut -d= -f2)
 ln -sfn "$CORE_TARGET" /snap/core20/current
 
-# Install Ruby 2.7 using install_assert.sh
+# Install Ruby 2.7 using snap_install.sh
 RUBY_INFO=$(./snap_download.sh ruby 2.7/stable "$ARCH" "$DOWNLOAD_DIR")
 RUBY_ASSERT=$(echo "$RUBY_INFO" | grep '^ASSERT=' | cut -d= -f2)
-RUBY_RESULT=$(./install_assert.sh "$RUBY_ASSERT" "$DOWNLOAD_DIR" /snap)
+RUBY_SNAP=$(echo "$RUBY_INFO" | grep '^SNAP=' | cut -d= -f2)
+RUBY_RESULT=$(./snap_install.sh "$RUBY_ASSERT" "$RUBY_SNAP" /snap)
 RUBY_TARGET=$(echo "$RUBY_RESULT" | grep '^TARGET_DIR=' | cut -d= -f2)
 ln -sfn "$RUBY_TARGET" /snap/ruby/current

--- a/snap_install.sh
+++ b/snap_install.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
-# Install a snap package using a downloaded .assert file to determine the name and revision
-# Usage: ./install_assert.sh <assert-file> [download-dir] [target-dir]
+# Install a snap package using a downloaded .assert and .snap file
+# Usage: ./snap_install.sh <assert-file> <snap-file> [target-dir]
 # - <assert-file>: Path to the .assert file
-# - [download-dir]: Directory containing the corresponding .snap (default dirname of assert)
-# - [target-dir]:   Parent directory for extraction (default /snap)
+# - <snap-file>:   Path to the corresponding .snap file
+# - [target-dir]:  Parent directory for extraction (default /snap)
 
 set -euo pipefail
 
 ASSERT_FILE=${1:?"Path to .assert file required"}
-DOWNLOAD_DIR=${2:-$(dirname "$ASSERT_FILE")}
+SNAP_FILE=${2:?"Path to .snap file required"}
 TARGET_PARENT=${3:-/snap}
 
 SNAP_NAME=$(awk -F': ' '/^snap-name:/ {print $2; exit}' "$ASSERT_FILE")
@@ -20,11 +20,6 @@ if [[ -z "$SNAP_NAME" || -z "$REVISION" ]]; then
   exit 1
 fi
 
-SNAP_FILE=$(find "$DOWNLOAD_DIR" -maxdepth 1 -name "${SNAP_NAME}_${REVISION}_*.snap" | head -n 1 || true)
-if [ -z "$SNAP_FILE" ]; then
-  echo "Snap file for $SNAP_NAME revision $REVISION not found in $DOWNLOAD_DIR" >&2
-  exit 1
-fi
 
 TARGET_DIR="$TARGET_PARENT/$SNAP_NAME/$REVISION"
 


### PR DESCRIPTION
## Summary
- rename `install_ruby.sh` to `setup.sh`
- rename `install_assert.sh` to `snap_install.sh`
- allow specifying both `.assert` and `.snap` files when installing
- update documentation and script references

## Testing
- `bash -n setup.sh snap_install.sh snap_download.sh activate.sh deactivate.sh`
- `shellcheck setup.sh snap_install.sh snap_download.sh activate.sh deactivate.sh`

------
https://chatgpt.com/codex/tasks/task_e_688a04126c94832bb0cca8d08dced22e