### PR TITLE
Split tests into separate scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,20 @@ This repository contains simple scripts for installing Ruby 2.7 from a Snap pack
 
 These scripts are experimental and assume a Linux environment with Snap and `squashfs-tools` available.
 
+### Test scripts
+
+Several test helpers are included to verify each part of the installation process.
+Run them individually or use `test.sh` to execute all of them in order.
+
+- `test_download.sh` – checks that `snap_download.sh` successfully downloads the
+  `.snap` and `.assert` files.
+- `test_install.sh` – verifies extraction of a downloaded Snap using
+  `snap_install.sh`.
+- `test_setup.sh` – runs `setup.sh` and confirms that Ruby is installed under
+  `/snap/ruby/current`.
+- `test_activate.sh` – sources `activate.sh`, confirms the Ruby version and that
+  the environment can be restored.
+
 ### Setup script for Codex
 
 ```bash

--- a/test.sh
+++ b/test.sh
@@ -1,35 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-ARCH=$(dpkg --print-architecture)
-
-# test snap_download.sh
-INFO=$(./snap_download.sh ruby 2.7/stable "$ARCH" test_dl)
-SNAP_PATH=$(echo "$INFO" | awk -F= '/^SNAP=/ {print $2}')
-ASSERT_PATH=$(echo "$INFO" | awk -F= '/^ASSERT=/ {print $2}')
-[ -f "$SNAP_PATH" ] && [ -f "$ASSERT_PATH" ]
-
-# test snap_install.sh
-INSTALL_INFO=$(./snap_install.sh "$ASSERT_PATH" "$SNAP_PATH" test_inst)
-TARGET_DIR=$(echo "$INSTALL_INFO" | awk -F= '/^TARGET_DIR=/ {print $2}')
-[ -x "$TARGET_DIR/bin/ruby" ]
-
-# test setup.sh
-sudo ./setup.sh
-[ -x /snap/ruby/current/bin/ruby ]
-
-# source activate.sh and check ruby
-source ./activate.sh
-ruby --version | grep -q "2.7"
-
-# check openssl
-ruby -ropenssl -e 'puts :ok'
-
-# deactivate and confirm ruby path changed
-deactivate
-if [ "$(which ruby)" = "/snap/ruby/current/bin/ruby" ]; then
-  echo "ruby path not restored" >&2
-  exit 1
-fi
-
-exit 0
+./test_download.sh
+./test_install.sh
+./test_setup.sh
+./test_activate.sh

--- a/test_activate.sh
+++ b/test_activate.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+source ./activate.sh
+ruby --version | grep -q "2.7"
+ruby -ropenssl -e 'puts :ok'
+
+deactivate
+if [ "$(which ruby)" = "/snap/ruby/current/bin/ruby" ]; then
+  echo "activate: failed" >&2
+  exit 1
+else
+  echo "activate: ok"
+fi

--- a/test_download.sh
+++ b/test_download.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -euo pipefail
+
+ARCH=$(dpkg --print-architecture)
+INFO=$(./snap_download.sh ruby 2.7/stable "$ARCH" test_dl)
+SNAP_PATH=$(echo "$INFO" | awk -F= '/^SNAP=/ {print $2}')
+ASSERT_PATH=$(echo "$INFO" | awk -F= '/^ASSERT=/ {print $2}')
+
+if [ -f "$SNAP_PATH" ] && [ -f "$ASSERT_PATH" ]; then
+  echo "download: ok"
+else
+  echo "download: failed" >&2
+  exit 1
+fi

--- a/test_install.sh
+++ b/test_install.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -euo pipefail
+
+ARCH=$(dpkg --print-architecture)
+INFO=$(./snap_download.sh ruby 2.7/stable "$ARCH" test_inst_dl)
+SNAP_PATH=$(echo "$INFO" | awk -F= '/^SNAP=/ {print $2}')
+ASSERT_PATH=$(echo "$INFO" | awk -F= '/^ASSERT=/ {print $2}')
+
+INSTALL_INFO=$(./snap_install.sh "$ASSERT_PATH" "$SNAP_PATH" test_inst)
+TARGET_DIR=$(echo "$INSTALL_INFO" | awk -F= '/^TARGET_DIR=/ {print $2}')
+
+if [ -x "$TARGET_DIR/bin/ruby" ]; then
+  echo "install: ok"
+else
+  echo "install: failed" >&2
+  exit 1
+fi

--- a/test_setup.sh
+++ b/test_setup.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -euo pipefail
+
+sudo ./setup.sh
+
+if [ -x /snap/ruby/current/bin/ruby ]; then
+  echo "setup: ok"
+else
+  echo "setup: failed" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- break up `test.sh` into smaller test scripts
- add `test_download.sh`, `test_install.sh`, `test_setup.sh`, and `test_activate.sh`
- update `README` with info about the new test scripts

## Testing
- `./test.sh`

------
https://chatgpt.com/codex/tasks/task_e_688a2c7bc520832bb6d8bade73c9a25e