### PR TITLE
Fix yq wrapper error for snaps without apps

### DIFF
--- a/snap_install.sh
+++ b/snap_install.sh
@@ -33,7 +33,8 @@ SNAP_YAML="$TARGET_DIR/meta/snap.yaml"
 if [ -f "$SNAP_YAML" ]; then
   mkdir -p /snap/bin
   SNAP_ARCH=$(dpkg --print-architecture)
-  for APP in $(yq -r '.apps | keys[]' "$SNAP_YAML"); do
+  # Use empty object when no apps are defined to avoid jq errors
+  for APP in $(yq -r '.apps // {} | keys[]' "$SNAP_YAML"); do
     CMD=$(yq -r ".apps.\"${APP}\".command" "$SNAP_YAML")
     [ "$CMD" = "null" ] && continue
     WRAPPER="/snap/bin/${APP}"


### PR DESCRIPTION
## Summary
- prevent jq error when installing snaps with no `apps` section

## Testing
- `bash -x ./snap_install.sh core20_2599.assert core20_2599_amd64.snap /snap`
- `sudo ./setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_688a3fd90b40832bb8bc1ed34a47f167