### PR TITLE
Update README to remove activate.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ This repository contains simple scripts for installing Ruby 2.7 from a Snap pack
 - **setup.sh** – Installs Ruby 2.7 using a downloaded Snap package,
   skipping extraction when the destination directory already exists and only
   running `apt` commands when required packages are missing.
-- **activate.sh** – Sets environment variables for running Ruby 2.7 and defines
-  a `deactivate` function to restore the previous environment.
 
 ## Usage
 
@@ -21,9 +19,8 @@ This repository contains simple scripts for installing Ruby 2.7 from a Snap pack
    extraction directory already exists, that step is skipped.
    Required packages are installed only when missing, so `apt-get update` and
    `apt-get install` are skipped if everything is already present.
-2. Source `activate.sh` to update the environment variables for your shell.
-   When you are done using this Ruby environment, run `deactivate` to
-   restore your previous settings.
+2. The wrapper scripts under `/snap/bin` make the installed commands available
+   automatically; no activation step is required.
 3. Use `snap_install.sh <assert> <snap>` to extract a previously downloaded
    package into `/snap/<name>/<revision>/`. Wrapper scripts are created under
    `/snap/bin` so the commands can be executed without specifying the full path.
@@ -41,8 +38,6 @@ Run them individually or use `test.sh` to execute all of them in order.
   `snap_install.sh`.
 - `test_setup.sh` – runs `setup.sh` and confirms that Ruby is installed under
   `/snap/ruby/current`.
-- `test_activate.sh` – sources `activate.sh`, confirms the Ruby version and that
-  the environment can be restored.
 
 ### Setup script for Codex
 
@@ -50,7 +45,4 @@ Run them individually or use `test.sh` to execute all of them in order.
 mise settings add idiomatic_version_file_enable_tools "[]"
 git clone https://github.com/naoto-aoki-fy/ruby27_snap.git ruby27_snap
 ./ruby27_snap/setup.sh
-
-echo >> "$HOME/.bashrc"
-echo source "$PWD"/ruby27_snap/activate.sh >> "$HOME/.bashrc"
 ```

--- a/test.sh
+++ b/test.sh
@@ -4,4 +4,3 @@ set -euo pipefail
 ./test_download.sh
 ./test_install.sh
 ./test_setup.sh
-./test_activate.sh


### PR DESCRIPTION
## Summary
- remove activate.sh references from README
- drop activate.sh test from test suite

## Testing
- `./test.sh`


------
https://chatgpt.com/codex/tasks/task_e_688a419caec0832bb2fbca6b4d0066e3