### PR TITLE
Clarify snap installation scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Ruby 2.7 Snap Installer
+# Snap Package Manual Installer
 
-This repository contains simple scripts for installing Ruby 2.7 from a Snap package and configuring the environment to use it.
+This repository contains simple scripts for manually installing Snap packages from downloaded `.snap` and `.assert` files. Ruby 2.7 is used as an example, but any Snap package can be installed in the same way.
 
 - **snap/snap_download.sh** – Downloads a package from the Snap repository. The
   destination directory for the `.snap` and `.assert` files can be specified as
@@ -9,21 +9,23 @@ This repository contains simple scripts for installing Ruby 2.7 from a Snap pack
   `.snap` files, extracting to `/snap/<name>/<revision>/` and creating
   wrapper scripts under `/snap/bin` for the commands defined in
   `meta/snap.yaml`.
-- **examples/setup_ruby27.sh** – Installs Ruby 2.7 using a downloaded Snap package,
-  skipping extraction when the destination directory already exists and only
-  running `apt` commands when required packages are missing.
+- **examples/setup_ruby27.sh** – Example script that installs Ruby 2.7 using these helpers.
+  Extraction is skipped when the destination directory already exists and `apt`
+  commands are run only when required packages are missing.
 
 ## Usage
 
-1. Run `examples/setup_ruby27.sh` as root to download and extract the Ruby 2.7 Snap package. If the
-   extraction directory already exists, that step is skipped.
-   Required packages are installed only when missing, so `apt-get update` and
-   `apt-get install` are skipped if everything is already present.
+1. Run `examples/setup_ruby27.sh` as root to download and install Ruby 2.7 as an example. If the
+   extraction directory already exists, that step is skipped. Required packages
+   are installed only when missing, so `apt-get update` and `apt-get install`
+   are skipped if everything is already present.
 2. The wrapper scripts under `/snap/bin` make the installed commands available
    automatically; no activation step is required.
 3. Use `snap_install.sh <assert> <snap>` to extract a previously downloaded
    package into `/snap/<name>/<revision>/`. Wrapper scripts are created under
    `/snap/bin` so the commands can be executed without specifying the full path.
+4. To install a different Snap package, call `snap_download.sh` and
+   `snap_install.sh` with the desired package name and channel.
 
 These scripts are experimental and assume a Linux environment with Snap and `squashfs-tools` available.
 
@@ -36,7 +38,7 @@ Run them individually or use `tests/test.sh` to execute all of them in order.
   `.snap` and `.assert` files.
 - `test_install.sh` – verifies extraction of a downloaded Snap using
   `snap/snap_install.sh`.
-- `test_setup.sh` – runs `examples/setup_ruby27.sh` and confirms that Ruby is installed under
+- `test_setup.sh` – runs the example script and confirms that Ruby is installed under
   `/snap/ruby/current`.
 
 ### Setup script for Codex


### PR DESCRIPTION
## Summary
- update README to explain that Ruby 2.7 is just an example
- describe tool as generic manual snap installer

## Testing
- `./tests/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_688a4582e640832b992de59d9045b837